### PR TITLE
Add GitHub Actions CI for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Files not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` that runs on every push and on PRs to `main`
- Single-job workflow using the latest stable Go version
- Mirrors `make check`: fmt check, vet, and test

Closes #4

## Test plan

- [ ] Verify the workflow runs on this PR
- [ ] Confirm `go fmt`, `go vet`, and `go test` steps all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)