### PR TITLE
feat(tui): add animated loading screen on startup

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -373,11 +373,18 @@ func (m Model) View() string {
 func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	previousView := m.currentView
 
+	// Ctrl+C always quits, even during loading
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+
+	// Block all other input during loading
+	if m.currentView == ViewLoading {
+		return m, nil
+	}
+
 	// Global keybindings that work in all views
 	switch msg.String() {
-	case "ctrl+c":
-		// Ctrl+C always quits
-		return m, tea.Quit
 	case "?":
 		if m.currentView == ViewHelp {
 			m.currentView = ViewList
@@ -385,11 +392,6 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.currentView = ViewHelp
 		}
 		m.clearStatusMessage()
-		return m, nil
-	}
-
-	// Block all other input during loading
-	if m.currentView == ViewLoading {
 		return m, nil
 	}
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -170,8 +170,8 @@ func TestNewModel(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
 
 		// Test initial view state
-		if model.currentView != ViewList {
-			t.Errorf("expected currentView to be ViewList, got %v", model.currentView)
+		if model.currentView != ViewLoading {
+			t.Errorf("expected currentView to be ViewLoading, got %v", model.currentView)
 		}
 
 		// Test dependencies
@@ -251,10 +251,6 @@ func TestNewModel(t *testing.T) {
 		if model.statusMessage != "" {
 			t.Errorf("expected statusMessage to be empty, got '%s'", model.statusMessage)
 		}
-		if model.showSpinner != false {
-			t.Errorf("expected showSpinner to be false, got %t", model.showSpinner)
-		}
-
 		// Test window dimensions
 		if model.width != 80 {
 			t.Errorf("expected width to be 80, got %d", model.width)
@@ -359,8 +355,8 @@ func TestViewStateTransitions(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
 
 		// Test initial state
-		if model.currentView != ViewList {
-			t.Errorf("expected initial view to be ViewList, got %v", model.currentView)
+		if model.currentView != ViewLoading {
+			t.Errorf("expected initial view to be ViewLoading, got %v", model.currentView)
 		}
 
 		// Test changing states
@@ -403,6 +399,7 @@ func TestMainListViewRendering(t *testing.T) {
 		appState := &state.State{}
 
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 
 		// Add mock time entries
 		model.timeEntries = []harvest.TimeEntry{
@@ -496,6 +493,7 @@ func TestMainListViewRendering(t *testing.T) {
 		appState := &state.State{}
 
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.currentDate = time.Date(2025, 1, 19, 0, 0, 0, 0, time.UTC)
 
 		output := model.View()
@@ -521,6 +519,7 @@ func TestMainListViewRendering(t *testing.T) {
 		appState := &state.State{}
 
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.loading = true
 
 		output := model.View()
@@ -542,6 +541,7 @@ func TestMainListViewRendering(t *testing.T) {
 		appState := &state.State{}
 
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.errorMessage = "Failed to fetch data"
 
 		output := model.View()
@@ -788,6 +788,7 @@ func TestNewEntryAction(t *testing.T) {
 
 	t.Run("given model with no projects when 'n' pressed then shows error message", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.projectsWithTasks = []harvest.ProjectWithTasks{}
 
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
@@ -858,6 +859,7 @@ func TestEditEntryAction(t *testing.T) {
 
 	t.Run("given model with locked entry when 'e' pressed then shows error message", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:       1,
@@ -881,6 +883,7 @@ func TestEditEntryAction(t *testing.T) {
 
 	t.Run("given model with no entries when 'e' pressed then nothing happens", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{}
 
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}}
@@ -929,6 +932,7 @@ func TestDeleteEntryAction(t *testing.T) {
 
 	t.Run("given model with locked entry when 'd' pressed then shows error message", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:        1,
@@ -953,6 +957,7 @@ func TestDeleteEntryAction(t *testing.T) {
 
 	t.Run("given model with running entry when 'd' pressed then shows error message", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:        1,
@@ -988,6 +993,7 @@ func TestStartStopTimerActions(t *testing.T) {
 
 	t.Run("given model with stopped unlocked entry when 's' pressed then starts timer", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:        1,
@@ -1013,6 +1019,7 @@ func TestStartStopTimerActions(t *testing.T) {
 
 	t.Run("given model with running entry when 's' pressed then stops timer", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:        1,
@@ -1160,6 +1167,7 @@ func TestDailyTotalDisplay(t *testing.T) {
 
 	t.Run("given model with multiple time entries when rendered then displays correct daily total", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:         1,
@@ -1202,6 +1210,7 @@ func TestDailyTotalDisplay(t *testing.T) {
 
 	t.Run("given model with no time entries when rendered then displays zero daily total", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{}
 		model.currentDate = time.Date(2025, 1, 19, 0, 0, 0, 0, time.UTC)
 
@@ -1219,6 +1228,7 @@ func TestDailyTotalDisplay(t *testing.T) {
 
 	t.Run("given model with fractional hours when rendered then displays correct time format", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:    1,
@@ -1241,6 +1251,7 @@ func TestDailyTotalDisplay(t *testing.T) {
 
 	t.Run("given model with large total when rendered then displays hours correctly", func(t *testing.T) {
 		model := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+		model.currentView = ViewList
 		model.timeEntries = []harvest.TimeEntry{
 			{
 				ID:    1,

--- a/internal/tui/loading_test.go
+++ b/internal/tui/loading_test.go
@@ -155,6 +155,18 @@ func TestLoadingView(t *testing.T) {
 		}
 	})
 
+	t.Run("given loading view when help key pressed then stays in ViewLoading", func(t *testing.T) {
+		model := newLoadingModel()
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}}
+		newModel, _ := model.Update(msg)
+		m := newModel.(Model)
+
+		if m.currentView != ViewLoading {
+			t.Errorf("expected currentView to remain ViewLoading, got %v", m.currentView)
+		}
+	})
+
 	t.Run("given loading view when ctrl+c pressed then quits", func(t *testing.T) {
 		model := newLoadingModel()
 

--- a/internal/tui/loading_test.go
+++ b/internal/tui/loading_test.go
@@ -1,0 +1,186 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/planetargon/harvest-tui/internal/config"
+	"github.com/planetargon/harvest-tui/internal/harvest"
+	"github.com/planetargon/harvest-tui/internal/state"
+)
+
+func newLoadingModel() Model {
+	cfg := &config.Config{Harvest: config.HarvestConfig{AccountID: "12345", AccessToken: "test-token"}}
+	client := harvest.NewClient("12345", "test-token")
+	appState := &state.State{Recents: []state.RecentEntry{}}
+	return NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+}
+
+func TestLoadingView(t *testing.T) {
+	t.Run("given new model when created then starts in ViewLoading", func(t *testing.T) {
+		model := newLoadingModel()
+
+		if model.currentView != ViewLoading {
+			t.Errorf("expected currentView to be ViewLoading, got %v", model.currentView)
+		}
+	})
+
+	t.Run("given loading view when only time entries arrive then stays in ViewLoading", func(t *testing.T) {
+		model := newLoadingModel()
+
+		msg := timeEntriesFetchedMsg{
+			entries: []harvest.TimeEntry{{ID: 1, Notes: "Test"}},
+		}
+		newModel, _ := model.Update(msg)
+		m := newModel.(Model)
+
+		if m.currentView != ViewLoading {
+			t.Errorf("expected currentView to remain ViewLoading, got %v", m.currentView)
+		}
+		if !m.timeEntriesLoaded {
+			t.Error("expected timeEntriesLoaded to be true")
+		}
+		if m.projectsLoaded {
+			t.Error("expected projectsLoaded to be false")
+		}
+	})
+
+	t.Run("given loading view when only projects arrive then stays in ViewLoading", func(t *testing.T) {
+		model := newLoadingModel()
+
+		msg := projectsWithTasksFetchedMsg{
+			projectsWithTasks: []harvest.ProjectWithTasks{
+				{
+					Project: harvest.Project{ID: 1, Name: "Test Project"},
+					Tasks:   []harvest.Task{{ID: 1, Name: "Test Task"}},
+				},
+			},
+		}
+		newModel, _ := model.Update(msg)
+		m := newModel.(Model)
+
+		if m.currentView != ViewLoading {
+			t.Errorf("expected currentView to remain ViewLoading, got %v", m.currentView)
+		}
+		if m.timeEntriesLoaded {
+			t.Error("expected timeEntriesLoaded to be false")
+		}
+		if !m.projectsLoaded {
+			t.Error("expected projectsLoaded to be true")
+		}
+	})
+
+	t.Run("given loading view when both fetches complete then transitions to ViewList", func(t *testing.T) {
+		model := newLoadingModel()
+
+		// First: time entries arrive
+		msg1 := timeEntriesFetchedMsg{
+			entries: []harvest.TimeEntry{{ID: 1, Notes: "Test"}},
+		}
+		newModel, _ := model.Update(msg1)
+		m := newModel.(Model)
+
+		// Second: projects arrive
+		msg2 := projectsWithTasksFetchedMsg{
+			projectsWithTasks: []harvest.ProjectWithTasks{
+				{
+					Project: harvest.Project{ID: 1, Name: "Test Project"},
+					Tasks:   []harvest.Task{{ID: 1, Name: "Test Task"}},
+				},
+			},
+		}
+		newModel, _ = m.Update(msg2)
+		m = newModel.(Model)
+
+		if m.currentView != ViewList {
+			t.Errorf("expected currentView to be ViewList, got %v", m.currentView)
+		}
+	})
+
+	t.Run("given loading view when both fetches complete in reverse order then transitions to ViewList", func(t *testing.T) {
+		model := newLoadingModel()
+
+		// First: projects arrive
+		msg1 := projectsWithTasksFetchedMsg{
+			projectsWithTasks: []harvest.ProjectWithTasks{},
+		}
+		newModel, _ := model.Update(msg1)
+		m := newModel.(Model)
+
+		// Second: time entries arrive
+		msg2 := timeEntriesFetchedMsg{
+			entries: []harvest.TimeEntry{},
+		}
+		newModel, _ = m.Update(msg2)
+		m = newModel.(Model)
+
+		if m.currentView != ViewList {
+			t.Errorf("expected currentView to be ViewList, got %v", m.currentView)
+		}
+	})
+
+	t.Run("given loading view when fetch errors occur then still transitions to ViewList", func(t *testing.T) {
+		model := newLoadingModel()
+
+		// Both fetches return errors
+		msg1 := timeEntriesFetchedMsg{
+			err: fmt.Errorf("network error"),
+		}
+		newModel, _ := model.Update(msg1)
+		m := newModel.(Model)
+
+		msg2 := projectsWithTasksFetchedMsg{
+			err: fmt.Errorf("network error"),
+		}
+		newModel, _ = m.Update(msg2)
+		m = newModel.(Model)
+
+		if m.currentView != ViewList {
+			t.Errorf("expected currentView to be ViewList even with errors, got %v", m.currentView)
+		}
+	})
+
+	t.Run("given loading view when key pressed then does nothing", func(t *testing.T) {
+		model := newLoadingModel()
+
+		// Press 'n' key during loading
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+		newModel, _ := model.Update(msg)
+		m := newModel.(Model)
+
+		if m.currentView != ViewLoading {
+			t.Errorf("expected currentView to remain ViewLoading, got %v", m.currentView)
+		}
+	})
+
+	t.Run("given loading view when ctrl+c pressed then quits", func(t *testing.T) {
+		model := newLoadingModel()
+
+		msg := tea.KeyMsg{Type: tea.KeyCtrlC}
+		_, cmd := model.Update(msg)
+
+		if cmd == nil {
+			t.Error("expected quit command to be returned")
+		}
+	})
+
+	t.Run("given loading view when rendered then contains harvest-themed message", func(t *testing.T) {
+		model := newLoadingModel()
+
+		output := model.View()
+
+		if !strings.Contains(output, "Harvesting your data") {
+			t.Error("expected output to contain 'Harvesting your data'")
+		}
+
+		if !strings.Contains(output, "Harvest Time Tracker") {
+			t.Error("expected output to contain title 'Harvest Time Tracker'")
+		}
+
+		if !strings.Contains(output, "ctrl+c") {
+			t.Error("expected output to contain ctrl+c keybinding")
+		}
+	})
+}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -79,6 +79,30 @@ func (m Model) buildShellBox(content string, width int, footerKeys []string) str
 	return strings.Join(boxedLines, "\n")
 }
 
+// renderLoadingView renders the loading screen shown during startup.
+func (m Model) renderLoadingView() string {
+	width := m.shellWidth()
+
+	titleBar := m.renderTitleBar()
+
+	loadingMsg := "  " + m.spinner.View() + " " + AccentText.Render("Harvesting your data...")
+
+	contentLines := []string{
+		titleBar,
+		"",
+		loadingMsg,
+		"",
+	}
+
+	content := strings.Join(contentLines, "\n")
+
+	footerKeys := []string{
+		RenderKeybinding("ctrl+c", "quit"),
+	}
+
+	return m.buildShellBox(content, width, footerKeys)
+}
+
 // renderStyledListView renders the main list view with proper styling.
 func (m Model) renderStyledListView() string {
 	// Calculate dimensions

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -16,7 +16,9 @@ func newTestModel() Model {
 	cfg := &config.Config{Harvest: config.HarvestConfig{AccountID: "12345", AccessToken: "test-token"}}
 	client := harvest.NewClient("12345", "test-token")
 	appState := &state.State{Recents: []state.RecentEntry{}}
-	return NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+	m := NewModel(cfg, client, appState, &harvest.User{FirstName: "Test", LastName: "User"})
+	m.currentView = ViewList
+	return m
 }
 
 func TestBoxBorderAlignment(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a `ViewLoading` state with animated spinner that displays on cold start while async API fetches (time entries + projects) are in-flight
- Block all user input except `ctrl+c` during loading to prevent misleading "No projects available" errors
- Transition to `ViewList` only after both fetches complete (even on errors, so error messages display properly in the list view)

Closes #13

## Test plan

- [ ] `make check` passes
- [ ] Launch app on slow network — spinner + "Harvesting your data..." message appears, then smooth transition to time entries
- [ ] `ctrl+c` works during loading
- [ ] Pressing `n` during loading does nothing (no misleading error)
- [ ] App transitions correctly even if one or both API calls fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)